### PR TITLE
fix spinner's unexpected behavior, when given an empty string as a lable

### DIFF
--- a/spinner.ts
+++ b/spinner.ts
@@ -1,6 +1,6 @@
 import { SPINNERS, SpinnerType } from './spinners.ts';
-import { clearCurrentLine, printOnCurrentLine, printNewLine } from './util.ts';
-import { red, green, bold, yellow } from 'https://deno.land/std/fmt/colors.ts';
+import { bold, green, red, yellow } from 'https://deno.land/std/fmt/colors.ts';
+import { clearCurrentLine, printNewLine, printOnCurrentLine } from './util.ts';
 
 export class Spinner {
   private static instance: Spinner;
@@ -36,7 +36,7 @@ export class Spinner {
     }
   }
 
-  public async start(text: string) {
+  public async start(text = "     ") {
     if (this.isRunning()) {
       throw new Error(
         "Can't start a new spinner while a spinner is already running!"


### PR DESCRIPTION
Fixed by adding a default value for the spinner's label, it's an empty string with only spaces

![ezgif-689bd7321ff5ad](https://github.com/user-attachments/assets/d59f147b-4196-45a4-9fbb-9d6bfdc0494d)
